### PR TITLE
Add prop to control caret alignment and group option height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop to control caret alignment inside `GroupOption`: `caretAlign`
+- Prop to adjust height of group option on mobile.
 
 ## [0.1.1] - 2020-05-08
 

--- a/react/GroupOption.css
+++ b/react/GroupOption.css
@@ -1,3 +1,17 @@
+.groupOption {
+  min-height: 3.625rem;
+}
+
+@media only screen and (min-width: 40em) {
+  .groupOption {
+    min-height: 4.125rem;
+  }
+}
+
 .optionDivider:last-of-type {
   display: none;
+}
+
+.caretWrapper {
+  height: 1.5rem;
 }

--- a/react/GroupOption.tsx
+++ b/react/GroupOption.tsx
@@ -6,6 +6,8 @@ import styles from './GroupOption.css'
 
 interface OptionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   selected?: boolean
+  caretAlign?: 'start' | 'center' | 'end'
+  lean?: boolean
 }
 
 const GroupOption: React.FC<OptionProps> = ({
@@ -13,20 +15,33 @@ const GroupOption: React.FC<OptionProps> = ({
   onClick = () => {},
   children,
   selected = false,
+  caretAlign = 'start',
+  lean = false,
 }) => {
   return (
     <Fragment>
       <button
         className={classnames(
-          'w-100 tl pointer db lh-copy c-on-base bg-base hover-bg-action-secondary ph5 pv4 pv5-ns bn flex justify-between',
-          className
+          styles.groupOption,
+          className,
+          'w-100 tl pointer db lh-copy c-on-base bg-base hover-bg-action-secondary ph5 pv5-ns bn flex items-center justify-between',
+          {
+            pv4: !lean,
+            pv3: lean,
+          }
         )}
         onClick={onClick}
         role="option"
         aria-selected={selected}
       >
         {children}
-        <span className="c-action-primary dib ml5">
+        <span
+          className={classnames(
+            styles.caretWrapper,
+            'c-action-primary ml5 inline-flex items-center',
+            `self-${caretAlign}`
+          )}
+        >
           <IconCaretRight />
         </span>
       </button>


### PR DESCRIPTION
#### What problem is this solving?

This PR adds two props to the `GroupOption` item that were needed to build the installment options list and payment option list in the Payment step for the new version of Checkout.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289). Enter in this workspace and proceed to the payment step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before:

![image](https://user-images.githubusercontent.com/10223856/81443157-438b5180-914b-11ea-91c6-7d77bc7bcaae.png)
![image](https://user-images.githubusercontent.com/10223856/81443226-6cabe200-914b-11ea-999a-91b838c03251.png)

After:

![image](https://user-images.githubusercontent.com/10223856/81443627-23a85d80-914c-11ea-940a-c68b253cf483.png)
![image](https://user-images.githubusercontent.com/10223856/81443674-3753c400-914c-11ea-83f4-7e01cca065f5.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->