### PR TITLE
Add Listbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Listbox component.
 
 ## [0.2.0] - 2020-05-11
 ### Added

--- a/react/Listbox.css
+++ b/react/Listbox.css
@@ -1,0 +1,23 @@
+:root {
+  --reach-listbox: 1;
+}
+
+.option:not([aria-selected="true"]) {
+  background-color: transparent;
+}
+
+.option:not([data-current=""]) {
+  padding-left: 2.125rem;
+}
+
+.option[data-current=""] {
+  padding-left: 0;
+}
+
+.option[data-current=""] .selectedIcon {
+  display: block;
+}
+
+.popover {
+  box-shadow: 0px 1px 16px rgba(46, 46, 46, 0.12);
+}

--- a/react/Listbox.css
+++ b/react/Listbox.css
@@ -21,3 +21,7 @@
 .popover {
   box-shadow: 0px 1px 16px rgba(46, 46, 46, 0.12);
 }
+
+.button [data-reach-listbox-arrow] {
+  margin-left: auto;
+}

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -51,9 +51,10 @@ export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
   return (
     <Button
       {...props}
+      arrow={arrow}
       className={classNames(
         className,
-        'h-100 flex items-center bg-base c-on-base ba bw1 b--muted-4 hover-b--muted-3 bt-0 bl-0 bb-0 pl5 pr3 outline-0 pointer'
+        'h-100 flex items-center bg-base c-on-base ba bw1 br2 b--muted-4 hover-b--muted-3 pv4 pv3-ns pl4 pr5 outline-0 pointer'
       )}
     />
   )

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -53,6 +53,7 @@ export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
       {...props}
       arrow={arrow}
       className={classNames(
+        styles.button,
         className,
         'h-100 flex items-center bg-base c-on-base ba bw1 br2 b--muted-4 hover-b--muted-3 pv4 pv3-ns pl4 pr5 outline-0 pointer'
       )}

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -1,0 +1,111 @@
+import {
+  ListboxInput as Input,
+  ListboxInputProps as InputProps,
+  ListboxButton as Button,
+  ListboxButtonProps as ButtonProps,
+  ListboxPopover as Popover,
+  ListboxPopoverProps as PopoverProps,
+  ListboxList as List,
+  ListboxListProps as ListProps,
+  ListboxOption as Option,
+  ListboxOptionProps as OptionProps,
+} from '@reach/listbox'
+import classNames from 'classnames'
+import React, { forwardRef } from 'react'
+
+import styles from './Listbox.css'
+
+export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
+  function ListboxInput({ className, ...props }, ref) {
+    return (
+      <Input {...props} ref={ref} className={classNames(className, 'w-100')} />
+    )
+  }
+)
+
+export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
+  className,
+  ...props
+}) => {
+  return (
+    <Button
+      {...props}
+      className={classNames(
+        className,
+        'h-100 flex items-center bg-base c-on-base ba bw1 b--muted-4 hover-b--muted-3 bt-0 bl-0 bb-0 pl5 pr3 outline-0 pointer'
+      )}
+    />
+  )
+}
+
+export const ListboxPopover = forwardRef<HTMLElement, PopoverProps>(
+  function ListboxPopover({ className, ...props }, ref) {
+    return (
+      <Popover
+        {...props}
+        ref={ref}
+        className={classNames(
+          className,
+          styles.popover,
+          'bg-base pv3 mt2 br2 ba bw1 b--muted-4 asbolute outline-0'
+        )}
+      />
+    )
+  }
+)
+
+export const ListboxList: React.FC<ListProps & { className?: string }> = ({
+  className,
+  ...props
+}) => {
+  return (
+    <List
+      {...props}
+      className={classNames(className, 'bg-base list ma0 pa0 outline-0')}
+    />
+  )
+}
+
+const SelectedIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
+  <svg
+    {...props}
+    width="10"
+    height="8"
+    viewBox="0 0 10 8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8.58484 0.234407L3.32991 5.48934L1.41516 3.57458C1.25767 3.42247 1.04673 3.3383 0.827788 3.34021C0.608842 3.34211 0.399402 3.42993 0.244579 3.58475C0.0897548 3.73958 0.00193415 3.94902 3.15668e-05 4.16796C-0.00187101 4.38691 0.0822967 4.59784 0.234407 4.75533L2.73954 7.26046C2.89613 7.41701 3.10849 7.50495 3.32991 7.50495C3.55134 7.50495 3.76369 7.41701 3.92029 7.26046L9.76559 1.41516C9.9177 1.25767 10.0019 1.04673 9.99997 0.827787C9.99806 0.608842 9.91024 0.399402 9.75542 0.244579C9.6006 0.0897547 9.39116 0.00193415 9.17221 3.15668e-05C8.95327 -0.00187101 8.74233 0.0822966 8.58484 0.234407Z"
+      fill="currentColor"
+    />
+  </svg>
+)
+
+export const ListboxOption: React.FC<OptionProps & { className?: string }> = ({
+  className,
+  children,
+  ...props
+}) => {
+  return (
+    <Option
+      {...props}
+      className={classNames(
+        className,
+        styles.option,
+        'flex items-center pointer bg-action-secondary pv3 pr7'
+      )}
+    >
+      <SelectedIcon className={classNames(styles.selectedIcon, 'dn pl5 pr3')} />
+      {children}
+    </Option>
+  )
+}
+
+export default {
+  ListboxInput,
+  ListboxButton,
+  ListboxPopover,
+  ListboxList,
+  ListboxOption,
+}

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -12,6 +12,7 @@ import {
 } from '@reach/listbox'
 import classNames from 'classnames'
 import React, { forwardRef } from 'react'
+import { IconCaretDown } from 'vtex.styleguide'
 
 import styles from './Listbox.css'
 
@@ -23,27 +24,11 @@ export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
   }
 )
 
-const ArrowDownIcon: React.FC<{ size?: number; color?: string }> = ({
-  size = 16,
-  color = 'currentColor',
-}) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-  >
-    <g fill={color}>
-      <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z" />
-    </g>
-  </svg>
-)
-
 export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
   className,
   arrow = (
-    <div className="c-action-primary flex items-center ml2">
-      <ArrowDownIcon size={16} />
+    <div className="c-action-primary">
+      <IconCaretDown />
     </div>
   ),
   ...props

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -23,8 +23,29 @@ export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
   }
 )
 
+const ArrowDownIcon: React.FC<{ size?: number; color?: string }> = ({
+  size = 16,
+  color = 'currentColor',
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+  >
+    <g fill={color}>
+      <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z" />
+    </g>
+  </svg>
+)
+
 export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
   className,
+  arrow = (
+    <div className="c-action-primary flex items-center ml2">
+      <ArrowDownIcon size={16} />
+    </div>
+  ),
   ...props
 }) => {
   return (

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -38,21 +38,22 @@ export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
   )
 }
 
-export const ListboxPopover = forwardRef<HTMLElement, PopoverProps>(
-  function ListboxPopover({ className, ...props }, ref) {
-    return (
-      <Popover
-        {...props}
-        ref={ref}
-        className={classNames(
-          className,
-          styles.popover,
-          'bg-base pv3 mt2 br2 ba bw1 b--muted-4 asbolute outline-0'
-        )}
-      />
-    )
-  }
-)
+export const ListboxPopover = forwardRef<
+  HTMLElement,
+  Omit<PopoverProps, 'unstable_observableRefs'>
+>(function ListboxPopover({ className, ...props }, ref) {
+  return (
+    <Popover
+      {...props}
+      ref={ref}
+      className={classNames(
+        className,
+        styles.popover,
+        'bg-base pv3 mt2 br2 ba bw1 b--muted-4 asbolute outline-0'
+      )}
+    />
+  )
+})
 
 export const ListboxList: React.FC<ListProps & { className?: string }> = ({
   className,

--- a/react/package.json
+++ b/react/package.json
@@ -10,6 +10,7 @@
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.113.2/public/@types/vtex.styleguide"
   },
   "dependencies": {
+    "@reach/listbox": "^0.10.2",
     "classnames": "^2.2.6",
     "react": "^16.13.1"
   },

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -2,4 +2,6 @@ import React from 'react'
 
 declare module 'vtex.styleguide' {
   const IconCaretRight: React.FC<any>
+
+  const IconCaretDown: React.FC<any>
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2,6 +2,86 @@
 # yarn lockfile v1
 
 
+"@reach/auto-id@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.2.tgz#a447af67241123dcb701ecd61931a2c786ed111e"
+  integrity sha512-PWFZevkHshiJV/z0L/5WQkWhe9QRzdZqC7N/JHRCoYo+odvCz9izXVRsxJf7p4sCuOCvnc8zNzAokFk2E1ZzDg==
+  dependencies:
+    "@reach/utils" "^0.10.2"
+    tslib "^1.11.2"
+
+"@reach/descendants@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.2.tgz#551c9f767a16bcad6d1abc41449bb46a12cd3ee3"
+  integrity sha512-jb2HlohyHZtNmm/VMDs5F/I3v+gs/7h6i++Uaubu5XiGkSN/3q5ecMh+cFHjsytQSLtp/7Yall/8+mb+KbIq2A==
+  dependencies:
+    "@reach/utils" "^0.10.2"
+    tslib "^1.11.2"
+
+"@reach/listbox@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/listbox/-/listbox-0.10.2.tgz#ab8216a871bb2767c73ff945536ab2dd875da128"
+  integrity sha512-UMQqFi0wYp36HKFVz6ESfj5KoDlsv3yROi0EAcbeEvsMaALKWUL1yRIIKnuKJPpB9t7Eq64osbbPRuSHNUOogA==
+  dependencies:
+    "@reach/auto-id" "^0.10.2"
+    "@reach/descendants" "^0.10.2"
+    "@reach/machine" "^0.10.2"
+    "@reach/popover" "^0.10.2"
+    "@reach/utils" "^0.10.2"
+    prop-types "^15.7.2"
+
+"@reach/machine@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/machine/-/machine-0.10.2.tgz#d0833de3361e451309dd00b7f4cce9485d457534"
+  integrity sha512-sXP26TSM1Fpsd98ktvrEDqRh0y4EPtVn5zweQSu+nP2O9JuqtTOiFOtS5hcLzp5KUZ5LBaFStNssrtGNAAPewA==
+  dependencies:
+    "@reach/utils" "^0.10.2"
+    "@xstate/fsm" "^1.4.0"
+    tslib "^1.11.2"
+
+"@reach/observe-rect@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.1.0.tgz#4e967a93852b6004c3895d9ed8d4e5b41895afde"
+  integrity sha512-kE+jvoj/OyJV24C03VvLt5zclb9ArJi04wWXMMFwQvdZjdHoBlN4g0ZQFjyy/ejPF1Z/dpUD5dhRdBiUmIGZTA==
+
+"@reach/popover@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.10.2.tgz#a0a047e1253f779c27f7839dfed6d2b82ad52328"
+  integrity sha512-NsRZJ1VjBOZLl4tbIAsR4CxYVsrtwYDvw11ZFqm+JszmsIMF2zT/WGnJ/dnbgUXIRg8gHs4YTwd9FvvU6iD8Bw==
+  dependencies:
+    "@reach/portal" "^0.10.2"
+    "@reach/rect" "^0.10.2"
+    "@reach/utils" "^0.10.2"
+    tabbable "^4.0.0"
+    tslib "^1.11.2"
+
+"@reach/portal@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.10.2.tgz#a2b4f69eaffad0115320e303d08ea57c8942b398"
+  integrity sha512-ZQU7Xlx9fBv1UurttmaS3dfWRT60Dn9Dtt/wmFyIf5Rquw64jNNL0XD5z0zqgVB+j5qnKERMf1hosYMU3BDSgQ==
+  dependencies:
+    "@reach/utils" "^0.10.2"
+    tslib "^1.11.2"
+
+"@reach/rect@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.10.2.tgz#6f1db6c7561e46c77505840c973d23fd5a57f7d4"
+  integrity sha512-Bk9J40toquXhvvdv4uFe4yIRm2Bkdi5ljYHL7NuBoOcn4xHnk/kjAeqmg8mDwaiZzo2vRekawGU5td2aeO/S0A==
+  dependencies:
+    "@reach/observe-rect" "^1.1.0"
+    "@reach/utils" "^0.10.2"
+    prop-types "^15.7.2"
+    tslib "^1.11.2"
+
+"@reach/utils@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.2.tgz#b835a7d02bd9fa73a009f7a8286d906745809a2f"
+  integrity sha512-zLYnmE5khVolwYd1wAqa+r6885KDILrZJfVXRa5yUEZ/8ygXhUleiwNpqrAifAD6fG/AUsLa2Azi6n3Nfxf08A==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^1.11.2"
+    warning "^4.0.3"
+
 "@types/classnames@^2.2.10":
   version "2.2.10"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
@@ -25,6 +105,16 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
+
+"@xstate/fsm@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.4.0.tgz#6fd082336fde4d026e9e448576189ee5265fa51a"
+  integrity sha512-uTHDeu2xI5E1IFwf37JFQM31RrH7mY7877RqPBS4ZqSNUwoLDuct8AhBWaXGnVizBAYyimVwgCyGa9z/NiRhXA==
+
 classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
@@ -40,7 +130,7 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -52,7 +142,7 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-prop-types@^15.6.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -75,6 +165,16 @@ react@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+tabbable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
+  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
+
+tslib@^1.11.2:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.99.0/public/@types/vtex.render-runtime":
   version "8.99.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.99.0/public/@types/vtex.render-runtime#2b514299e4afe4cb940de52278ff4c67525d4985"
@@ -82,3 +182,10 @@ react@^16.13.1:
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.113.2/public/@types/vtex.styleguide":
   version "9.113.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.113.2/public/@types/vtex.styleguide#4e9917c30fe1a2ae3577083e60d16ac4b52537f2"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the Listbox component, so we can use it accross differente apps in the Checkout. Currently, this component was only used inside the `vtex.phone-field` app, but we want to use it in `place-components` as well (for the `LocationCountry` component).

Notice: this component is only a copy-and-paste from the implementation in `phone-field`, with only a few minor tweaks.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/). Currently, the phone field in the profile step is using this component.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Profile:
![image](https://user-images.githubusercontent.com/10223856/82602880-19dd1c00-9b88-11ea-89a1-ac1192959c20.png)

Shipping:
![image](https://user-images.githubusercontent.com/10223856/82701220-1d36dd00-9c46-11ea-8dab-059474f48812.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->