### PR TITLE
Add prop variation to listbox button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Prop `plain` to `ListboxButton` to remove borders.
+- Prop `variation` to `ListboxButton` to control component appearance.
 
 ## [0.3.0] - 2020-05-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `plain` to `ListboxButton` to remove borders.
 
 ## [0.3.0] - 2020-05-28
 ### Added

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -24,10 +24,11 @@ export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
   }
 )
 
-export const ListboxButton: React.FC<ButtonProps & {
-  className?: string
-  plain: boolean
-}> = ({
+export const ListboxButton: React.FC<ButtonProps &
+  React.HTMLAttributes<HTMLSpanElement> & {
+    className?: string
+    plain: boolean
+  }> = ({
   className,
   plain = false,
   arrow = (

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -24,13 +24,15 @@ export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
   }
 )
 
-export const ListboxButton: React.FC<ButtonProps &
-  React.HTMLAttributes<HTMLSpanElement> & {
-    className?: string
-    plain: boolean
-  }> = ({
+interface ListboxButtonProps
+  extends ButtonProps,
+    Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  variation?: 'default' | 'plain'
+}
+
+export const ListboxButton: React.FC<ListboxButtonProps> = ({
   className,
-  plain = false,
+  variation = 'default',
   arrow = (
     <div className="c-action-primary">
       <IconCaretDown />
@@ -46,7 +48,7 @@ export const ListboxButton: React.FC<ButtonProps &
         styles.button,
         className,
         'h-100 flex items-center bg-base c-on-base pv4 pv3-ns pl4 pr5 outline-0 pointer',
-        { 'ba bw1 br2 b--muted-4 hover-b--muted-3': !plain }
+        { 'ba bw1 br2 b--muted-4 hover-b--muted-3': variation === 'default' }
       )}
     />
   )

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -24,8 +24,12 @@ export const ListboxInput = forwardRef<HTMLDivElement, InputProps>(
   }
 )
 
-export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
+export const ListboxButton: React.FC<ButtonProps & {
+  className?: string
+  plain: boolean
+}> = ({
   className,
+  plain = false,
   arrow = (
     <div className="c-action-primary">
       <IconCaretDown />
@@ -40,7 +44,8 @@ export const ListboxButton: React.FC<ButtonProps & { className?: string }> = ({
       className={classNames(
         styles.button,
         className,
-        'h-100 flex items-center bg-base c-on-base ba bw1 br2 b--muted-4 hover-b--muted-3 pv4 pv3-ns pl4 pr5 outline-0 pointer'
+        'h-100 flex items-center bg-base c-on-base pv4 pv3-ns pl4 pr5 outline-0 pointer',
+        { 'ba bw1 br2 b--muted-4 hover-b--muted-3 ': !plain }
       )}
     />
   )

--- a/react/Listbox.tsx
+++ b/react/Listbox.tsx
@@ -45,7 +45,7 @@ export const ListboxButton: React.FC<ButtonProps & {
         styles.button,
         className,
         'h-100 flex items-center bg-base c-on-base pv4 pv3-ns pl4 pr5 outline-0 pointer',
-        { 'ba bw1 br2 b--muted-4 hover-b--muted-3 ': !plain }
+        { 'ba bw1 br2 b--muted-4 hover-b--muted-3': !plain }
       )}
     />
   )


### PR DESCRIPTION
#### What problem is this solving?

Adds the `plain` prop to the `ListboxButton` component. This prop removes all borders from this component and will be useful for a more fine-grained control of the border by a parent component (see GIF below).

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com/checkout/#/profile).

You can view the new behavior on the phone field in the profile step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![listbox-plain-border](https://user-images.githubusercontent.com/10223856/84181014-d8d97880-aa5e-11ea-9685-0ee3dc4461f5.gif)

We can now control the border color more precisely from a parent component.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->