### PR TITLE
CHK-441: Add none borderPosition prop and fix selected group option mobile style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Option `none` for `borderPosition` prop of `ListGroup`.
+
+### Fixed
+- Layout for selected group option in mobile with left padding.
 
 ## [0.5.0] - 2020-11-12
 ### Added

--- a/react/GroupOption.tsx
+++ b/react/GroupOption.tsx
@@ -30,7 +30,7 @@ const GroupOption: React.FC<OptionProps> = ({
         className={classnames(
           styles.groupOption,
           className,
-          'w-100 tl pointer db lh-copy c-on-base bg-base hover-bg-action-secondary ph5-ns pv5-ns flex items-center justify-between bn',
+          'w-100 tl pointer db lh-copy c-on-base bg-base hover-bg-action-secondary ph5 pv5-ns flex items-center justify-between bn',
           {
             pv4: !lean,
             pv3: lean,
@@ -52,7 +52,7 @@ const GroupOption: React.FC<OptionProps> = ({
         </span>
       </button>
       {(!isLast || borderPosition === 'top') && (
-        <div className="w-100 pr5 pr0-ns pl5-ns">
+        <div className="w-100 pr5 pr0-ns pl5">
           <Divider orientation="horizontal" />
         </div>
       )}

--- a/react/ListGroup.tsx
+++ b/react/ListGroup.tsx
@@ -2,14 +2,14 @@ import classnames from 'classnames'
 import React, { useContext, useMemo, createContext } from 'react'
 
 interface ListContext {
-  borderPosition: 'top' | 'bottom'
+  borderPosition: 'top' | 'bottom' | 'none'
 }
 
 const ctx = createContext<ListContext | undefined>(undefined)
 
 export const useListContext = () => useContext(ctx)
 
-const ListGroup: React.FC<{ borderPosition?: 'top' | 'bottom' }> = ({
+const ListGroup: React.FC<{ borderPosition?: 'top' | 'bottom' | 'none' }> = ({
   children,
   borderPosition = 'top',
 }) => {
@@ -21,9 +21,10 @@ const ListGroup: React.FC<{ borderPosition?: 'top' | 'bottom' }> = ({
   )
 
   return (
-    <div className="nh5 nh0-ns pl5 pl0-ns" role="group">
+    <div className="nh5 nh0-ns" role="group">
       <div
-        className={classnames('b--muted-4', {
+        className={classnames({
+          'b--muted-4': borderPosition !== 'none',
           bt: borderPosition === 'top',
           bb: borderPosition === 'bottom',
         })}


### PR DESCRIPTION
#### What problem is this solving?

Fixes some layout issues regarding the list group/option group components. On mobile, the selected group option component had a left padding which it shouldn't, and with selected options list a top border was being rendered where it shouldn't, and this PR fixes that.

#### How should this be manually tested?

[Workspace](https://billing--checkoutio.myvtex.com).

You can see the fixes on the cart page. ~I'll add some screenshots here to illustrate the fixes issues.~ Screenshots below

Before:
![image](https://user-images.githubusercontent.com/10223856/99281921-d4856880-2811-11eb-88f4-773cf659ce27.png)

After:
![image](https://user-images.githubusercontent.com/10223856/99282312-4a89cf80-2812-11eb-87e5-658fe2770750.png)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
